### PR TITLE
Fixed issue#2. Catch CorruptFileException and record result to a log …

### DIFF
--- a/ncmdumpGUI/Main.cs
+++ b/ncmdumpGUI/Main.cs
@@ -20,6 +20,7 @@ namespace ncmdumpGUI
         }
 
         FileInfo configFileInfo;
+        FileInfo logFileInfo;
 
         private void Main_Load(object sender, EventArgs e)
         {
@@ -100,6 +101,11 @@ namespace ncmdumpGUI
             IAsyncResult asyncResult;
             try
             {
+                // create log file base on time
+                string logFilename = AppDomain.CurrentDomain.BaseDirectory + "log" + DateTime.Now.ToString("yyyyMMddmmss") + ".txt";
+                logFileInfo = new FileInfo(logFilename);
+                StreamWriter logFileWriter = logFileInfo.CreateText();
+
                 BeginInvoke(progressDialogControl.delProgressDlg, ProgressStatusType.BackgroundWorkStart, "正在转换文件，请稍候......");
                 while (!progressDialogControl.IsProgressDlgHandleCreate)
                 {
@@ -137,16 +143,42 @@ namespace ncmdumpGUI
 
                 DirectoryInfo ncmDirctoryInfo = new DirectoryInfo(ncmFolderPath);
                 DirectoryInfo mp3DirctoryInfo = new DirectoryInfo(mp3FolderPath);
-                foreach (FileInfo fileInfo in ncmDirctoryInfo.GetFiles("*.ncm"))
-                {
-                    BeginInvoke(progressDialogControl.delProgressDlg, ProgressStatusType.BackgroundWorkUpdate, "转换：" + fileInfo.Name);
-                    NeteaseCrypto neteaseFile = new NeteaseCrypto(fileInfo);
-                    neteaseFile.Dump(mp3FolderPath);
-                }
 
+                try
+                {
+                    foreach (FileInfo fileInfo in ncmDirctoryInfo.GetFiles("*.ncm"))
+                    {
+                        BeginInvoke(progressDialogControl.delProgressDlg, ProgressStatusType.BackgroundWorkUpdate, "转换：" + fileInfo.Name);
+                        try
+                        {
+                            NeteaseCrypto neteaseFile = new NeteaseCrypto(fileInfo);
+                            neteaseFile.Dump(mp3FolderPath);
+                        }
+                        catch (TagLib.CorruptFileException ex) //Ignore "MPEG audio header not found.", the error means the audio header does not contain artist, song, etc.. details and their absence should never prevent audio stream loading.
+                        {
+                            logFileWriter.WriteLine("Warning：" + fileInfo.Name + " " + ex.Message);
+                            asyncResult = BeginInvoke(delUIThreadOperation);
+                            EndInvoke(asyncResult);
+                            BeginInvoke(progressDialogControl.delProgressDlg, ProgressStatusType.BackgroundWorkStop, "Warning：" + fileInfo.Name + " " + ex.Message);
+                            EndInvoke(asyncResult);
+                            continue;
+                        }
+                        catch (Exception ex) // Unknown error, to give user a tips and continue processing.
+                        {
+                            logFileWriter.WriteLine("Error：" + fileInfo.Name + " " + ex.Message);
+                            MessageBox.Show("转换失败！" + ex.Message + " 点击继续转换", "", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                            continue;
+                        }
+                    }
+                }
+                finally
+                {
+                    if (logFileWriter != null)
+                        logFileWriter.Close();
+                }
                 delUIThreadOperation = new DelUIThreadOperation(delegate ()
                 {
-                    MessageBox.Show("转换完成！","", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    MessageBox.Show("转换完成！请查看转换日志：" + logFilename,"", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 });
                 asyncResult = BeginInvoke(delUIThreadOperation);
                 EndInvoke(asyncResult);


### PR DESCRIPTION
#2 错误是因为音频头不包含艺术家，歌曲等细节， 这些标签是可选的，不会妨碍音频流的加载，转化结果是正常的。
可参考[codeproject上帖子](https://www.codeproject.com/Questions/5318852/MPEG-audio-header-not-found)
修改：
1. 循环中Catch该异常类型CorruptFileException
优化&新增：
1. 转换某个文件失败后继续尝试转换其他文件
2. 转换时生成转换日志文件